### PR TITLE
don't group imports if g:packageSepDepth is 0

### DIFF
--- a/plugin/javaimports.vim
+++ b/plugin/javaimports.vim
@@ -76,17 +76,19 @@ fun! s:JavaSortImport()
             endif
         endfor
         1
-        while search(s:importPattern, 'W') > 0
-            let curLine = getline(".")
-            let curMatch = substitute(curLine, '\(^\s*import\s\+\(\.\?[^\.]\+\)\{0,' . g:packageSepDepth . '\}\).*', '\1', "")
-            if (curMatch == curLine)
-                let curMatch = substitute(curMatch, '\(.*\)\..*', '\1', "")
-            endif
-            while match(getline("."), curMatch) >= 0
-                normal! j
+        if (g:packageSepDepth > 0)
+            while search(s:importPattern, 'W') > 0
+                let curLine = getline(".")
+                let curMatch = substitute(curLine, '\(^\s*import\s\+\(\.\?[^\.]\+\)\{0,' . g:packageSepDepth . '\}\).*', '\1', "")
+                if (curMatch == curLine)
+                    let curMatch = substitute(curMatch, '\(.*\)\..*', '\1', "")
+                endif
+                while match(getline("."), curMatch) >= 0
+                    normal! j
+                endwhile
+                normal! O
             endwhile
-            normal! O
-        endwhile
+        endif
         if getline(".") =~ "^$"
             delete
         endif


### PR DESCRIPTION
Someone may not want to group imports. Setting g:packageSepDepth to 0 is good way for them to disable grouping
